### PR TITLE
🐛 Fix sorting of testresults

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -41,9 +41,9 @@ function printStepRunsSummary(stepResults) {
     return a - b;
   });
 
-  const fastestRun = stepResults[0];
-  const medianResult = median(stepResults);
-  const slowestRun = stepResults[stepResults.length - 1];
+  const fastestRun = sortedResults[0];
+  const medianResult = median(sortedResults);
+  const slowestRun = sortedResults[stepResults.length - 1];
 
   console.log(`    ${fastestRun} ms | ${medianResult} ms | ${slowestRun} ms`);
 }


### PR DESCRIPTION
calculating the fastest, median and slowest result relies on the results being sorted.
This branch makes these calculations use the sorted results.

Before:
```
datastore endpoint test
  seed 50 users
    run 1: 884 ms
    run 2: 525 ms
    run 3: 488 ms
    run 4: 438 ms
    run 5: 423 ms
    884 ms | 488 ms | 423 ms

  fetch all users
    run 1: 143 ms
    run 2: 46 ms
    run 3: 40 ms
    run 4: 39 ms
    run 5: 44 ms
    143 ms | 40 ms | 44 ms

  clear all users
    run 1: 475 ms
    run 2: 398 ms
    run 3: 365 ms
    run 4: 382 ms
    run 5: 356 ms
    475 ms | 365 ms | 356 ms
```

After:
```
datastore endpoint test
  seed 50 users
    run 1: 597 ms
    run 2: 463 ms
    run 3: 478 ms
    run 4: 473 ms
    run 5: 455 ms
    455 ms | 473 ms | 597 ms

  fetch all users
    run 1: 130 ms
    run 2: 47 ms
    run 3: 61 ms
    run 4: 62 ms
    run 5: 44 ms
    44 ms | 61 ms | 130 ms

  clear all users
    run 1: 824 ms
    run 2: 374 ms
    run 3: 360 ms
    run 4: 348 ms
    run 5: 341 ms
    341 ms | 360 ms | 824 ms
```

Notice how the `min | median | max` values were incorrect before